### PR TITLE
main: fix running `make` with correct NDK path

### DIFF
--- a/main.v
+++ b/main.v
@@ -249,7 +249,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 
 	// check if raylib floder is found else clone it
 	if !is_raylib {
-		return error('vab-raylib extension requires module `raylib` to be installed...')
+		return error('vab-raylib extension requires module `raylib` to be imported in the project...')
 	}
 	v_raylib_module_path := os.join_path(vxt.vmodules() or {
 		return error('${err_sig}: vmodules folder not found')

--- a/main.v
+++ b/main.v
@@ -29,7 +29,6 @@ const default_vab_sdl_options = cli.Options{
 
 const accepted_input_files = ['.v', '.apk', '.aab']
 
-	
 // main is a rough reimplementation of `vab`'s main function
 fn main() {
 	mut args := arguments()
@@ -144,11 +143,11 @@ fn main() {
 	// raylib
 	aco := opt.as_android_compile_options()
 	comp_opt := android.CompileOptions{
-	 	...aco
-	 	cache_key: if os.is_dir(input) || input_ext == '.v' { opt.input } else { '' }
-	 }
-	 compile_raylib(comp_opt, opt) or {
-		util.vab_error('Packaging did not succeed', details: '${err}')
+		...aco
+		cache_key: if os.is_dir(input) || input_ext == '.v' { opt.input } else { '' }
+	}
+	compile_raylib(comp_opt, opt) or {
+		util.vab_error('Compiling did not succeed', details: '${err}')
 		exit(1)
 	}
 	// =================================
@@ -156,7 +155,7 @@ fn main() {
 	apo := opt.as_android_package_options()
 	pck_opt := android.PackageOptions{
 		...apo
-		keystore:   keystore
+		keystore: keystore
 	}
 	android.package(pck_opt) or {
 		util.vab_error('Packaging did not succeed', details: '${err}')
@@ -196,7 +195,6 @@ fn deploy(deploy_opt android.DeployOptions) {
 	}
 }
 
-
 fn build_raylib(opt android.CompileOptions, raylib_path string, arch string) ! {
 	build_path := os.join_path(raylib_path, 'build')
 	// check if the library already exists or compile it
@@ -204,7 +202,7 @@ fn build_raylib(opt android.CompileOptions, raylib_path string, arch string) ! {
 		return
 	} else {
 		src_path := os.join_path(raylib_path, 'src')
-		ndk_path := ndk.root()
+		ndk_path := ndk.root_version(opt.ndk_version)
 		os.execute('make -C ${src_path} clean')
 		arch_name := if arch == 'arm64-v8a' {
 			'arm64'
@@ -228,9 +226,9 @@ fn build_raylib(opt android.CompileOptions, raylib_path string, arch string) ! {
 	}
 }
 
-fn download_raylib(raylib_path string) {
+fn download_raylib(raylib_c_path string) {
 	// clone raylib from github
-	os.execute('git clone https://github.com/raysan5/raylib.git ${raylib_path}')
+	os.execute('git clone https://github.com/raysan5/raylib.git ${raylib_c_path}')
 }
 
 pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
@@ -243,7 +241,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 	v_meta_dump := android.compile_v_to_c(opt) or {
 		return IError(android.CompileError{
 			kind: .v_to_c
-			err: err.msg()
+			err:  err.msg()
 		})
 	}
 
@@ -251,26 +249,26 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 
 	// check if raylib floder is found else clone it
 	if !is_raylib {
-		return error('THIS vab extension need build raylib, package raylib is mising.....')
+		return error('vab-raylib extension requires module `raylib` to be installed...')
 	}
-	raylib_path := os.join_path(vxt.vmodules() or {
-		return error('${err_sig}:vmodules folder not found')
-	}, 'raylib', 'raylib')
-	if os.exists(raylib_path) {
+	v_raylib_module_path := os.join_path(vxt.vmodules() or {
+		return error('${err_sig}: vmodules folder not found')
+	}, 'raylib')
+	raylib_c_path := os.join_path(v_raylib_module_path, 'raylib')
+	if os.exists(raylib_c_path) {
 		for arch in opt.archs {
-			build_raylib(opt, raylib_path, arch) or {
+			build_raylib(opt, raylib_c_path, arch) or {
 				return error('cant build raylib ERROR: ${err}')
 			}
 		}
 	} else {
-		download_raylib(raylib_path)
+		download_raylib(raylib_c_path)
 		for arch in opt.archs {
-			build_raylib(opt, raylib_path, arch) or {
+			build_raylib(opt, raylib_c_path, arch) or {
 				return error('cant build raylib ERROR: ${err}')
 			}
 		}
 	}
-
 
 	v_cflags := v_meta_dump.c_flags
 	imported_modules := v_meta_dump.imports
@@ -335,7 +333,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 	vicd := compile_v_imports_c_dependencies(opt, imported_modules) or {
 		return IError(android.CompileError{
 			kind: .c_to_o
-			err: err.msg()
+			err:  err.msg()
 		})
 	}
 	mut o_files := vicd.o_files.clone()
@@ -405,7 +403,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 	android_includes << '-I"' + os.join_path(ndk_sysroot, 'usr', 'include') + '"'
 	android_includes << '-I"' + os.join_path(ndk_sysroot, 'usr', 'include', 'android') + '"'
 
-	//is_debug_build := opt.is_debug_build()
+	// is_debug_build := opt.is_debug_build()
 
 	// add needed flags for raylib
 	ldflags << '-lEGL'
@@ -413,8 +411,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 	ldflags << '-u ANativeActivity_onCreate'
 	ldflags << '-lOpenSLES'
 	ldflags << '-DPLATFORM_ANDROID'
-	ldflags << '-DGRAPHICS_API_OPENGL_ES2'   
-
+	ldflags << '-DGRAPHICS_API_OPENGL_ES2'
 
 	if uses_gc {
 		includes << '-I"' + os.join_path(v_thirdparty_dir, 'libgc', 'include') + '"'
@@ -431,7 +428,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 
 	mut arch_cc := map[string]string{}
 	mut arch_libs := map[string]string{}
-	for arch in archs {		
+	for arch in archs {
 		compiler := ndk.compiler(.c, opt.ndk_version, arch, opt.api_level) or {
 			return error('${err_sig}: failed getting NDK compiler.\n${err}')
 		}
@@ -455,17 +452,17 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 
 	mut jobs := []util.ShellJob{}
 
-	mut src_dir := os.join_path(raylib_path, "raylib", "src")
+	mut src_dir := os.join_path(raylib_c_path, 'src')
 	includes << '-I"' + src_dir + '" '
 
 	if opt.verbosity > 0 {
 		println('Include ${src_dir}')
 	}
 	for arch in archs {
-		mut build_dir0 := os.join_path(raylib_path, "raylib", "build", arch)
-	    if opt.verbosity > 1 {
-	    	println('Include ${build_dir0}')
-	    }
+		mut build_dir0 := os.join_path(raylib_c_path, 'build', arch)
+		if opt.verbosity > 1 {
+			println('Include ${build_dir0}')
+		}
 		arch_cflags[arch] << [
 			'-target ' + ndk.compiler_triplet(arch) + opt.min_sdk_version.str(),
 			'-L"' + build_dir0 + '" ',
@@ -511,7 +508,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 	util.run_jobs(jobs, opt.parallel, opt.verbosity) or {
 		return IError(android.CompileError{
 			kind: .c_to_o
-			err: err.msg()
+			err:  err.msg()
 		})
 	}
 	jobs.clear()
@@ -556,7 +553,7 @@ pub fn compile_raylib(opt android.CompileOptions, cliO cli.Options) ! {
 		util.run_jobs(jobs, opt.parallel, opt.verbosity) or {
 			return IError(android.CompileError{
 				kind: .o_to_so
-				err: err.msg()
+				err:  err.msg()
 			})
 		}
 
@@ -647,7 +644,7 @@ pub fn v_dump_meta(opt VCompileOptions) !VMetaInfo {
 	// VCROSS_COMPILER_NAME is needed (on at least Windows) - just get whatever compiler is available
 	os.setenv('VCROSS_COMPILER_NAME', ndk.compiler_min_api(.c, ndk.default_version(),
 		'arm64-v8a') or { '' }, true)
-	
+
 	verbosity_print_cmd(v_cmd, opt.verbosity)
 	v_dump_res := run(v_cmd)
 	if opt.verbosity > 3 {
@@ -819,9 +816,6 @@ pub fn compile_v_imports_c_dependencies(opt android.CompileOptions, imported_mod
 		a_files: a_files
 	}
 }
-			
-
-			
 
 // verbosity_print_cmd prints information about the `args` at certain `verbosity` levels.
 fn verbosity_print_cmd(args []string, verbosity int) {


### PR DESCRIPTION
This PR fixes it so `make` get the correct (default) NDK path detected by `vab`. But it leaves me with this compile error:
```
Compiling V import C dependencies (.c to .o for ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']) in parallel
Compiling libgc (arm64-v8a) via -gc flag
Running aarch64-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/arm64-v8a/gc.o"

Compiling libgc (armeabi-v7a) via -gc flag
Running armv7a-linux-androideabi33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/armeabi-v7a/gc.o"

Compiling libgc (x86) via -gc flag
Running i686-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/x86/gc.o"

Compiling libgc (x86_64) via -gc flag
Running x86_64-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/x86_64/gc.o"

Running aarch64-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/arm64-v8a/gc.o"

Running armv7a-linux-androideabi33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/armeabi-v7a/gc.o"

Running i686-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/x86/gc.o"

Running x86_64-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android33-clang -O0 -fPIC -Wall -Wextra -I"/home/lmp/Projects/v/thirdparty/libgc/include" -DGC_THREADS=1 -DGC_BUILTIN_ATOMIC=1 -D_REENTRANT -DUSE_MMAP -c "/home/lmp/Projects/v/thirdparty/libgc/gc.c" -o "/tmp/vab/build/o/x86_64/gc.o"

Compiling C output for ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'] in parallel
Include /home/lmp/.vmodules/raylib/raylib/src
Include /home/lmp/.vmodules/raylib/raylib/build/arm64-v8a
Include /home/lmp/.vmodules/raylib/raylib/build/armeabi-v7a
Include /home/lmp/.vmodules/raylib/raylib/build/x86
Include /home/lmp/.vmodules/raylib/raylib/build/x86_64
Running aarch64-linux-android33-clang From: /tmp/vt
/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android33-clang -O0 -fPIC -fvisibility=hidden -ffunction-sections -fdata-sections -ferror-limit=1 -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-result -Wno-unused-function -Wno-unused-label -Wno-missing-braces -Werror=implicit-function-declaration -Wno-enum-conversion -Wno-unused-value -Wno-pointer-sign -Wno-incompatible-pointer-types -I"/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include" -I"/home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/android" -I "external/android/native_app_glue" -I"/home/lmp/Projects/v/thirdparty/libgc/include" -I"/home/lmp/.vmodules/raylib/raylib/src"  -D PLATFORM_ANDROID -D GRAPHICS_API_OPENGL_ES2 -D_DEFAULT_SOURCE -DAPPNAME="v_test_app" -DANDROID -D__ANDROID__ -DANDROIDVERSION=33 -m64 -target aarch64-linux-android21 -L"/home/lmp/.vmodules/raylib/raylib/build/arm64-v8a"  -L"/home/lmp/.vmodules/raylib/raylib/src"  -I"/home/lmp/.vmodules/raylib/raylib/build/arm64-v8a"  -c "/tmp/vab/v_android.c" -l:libraylib.a -l:raylib -o "/tmp/vab/build/o/arm64-v8a/v_test_app.o"
error: Compiling did not succeed
details:
  vab.android.CompileError: failed to compile .c to .o:
  /home/lmp/env/Android/android-sdk-linux/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android33-clang failed with return code 1:
  clang: warning: -l:libraylib.a: 'linker' input unused [-Wunused-command-line-argument]
  clang: warning: -l:raylib: 'linker' input unused [-Wunused-command-line-argument]
  clang: warning: argument unused during compilation: '-L/home/lmp/.vmodules/raylib/raylib/build/arm64-v8a' [-Wunused-command-line-argument]
  clang: warning: argument unused during compilation: '-L/home/lmp/.vmodules/raylib/raylib/src' [-Wunused-command-line-argument]
  /tmp/vab/v_android.c:635:2: error: VERROR_MESSAGE Header file "android-ext/native_app_glue/android_native_app_glue.c", needed for module `raylib` was not found. Please install the corresponding development headers.
    635 | #error VERROR_MESSAGE Header file "android-ext/native_app_glue/android_native_app_glue.c", needed for module `raylib` was not found. Please install the corresponding development headers.
        |  ^
  fatal error: too many errors emitted, stopping now [-ferror-limit=]
  2 errors generated.
```
